### PR TITLE
CA-4021 Updated WorkflowSystem attributes.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+=== 0.6.5
+
+* Brought the attributes for WorkflowSystem up to date for both V1 and V2.
+
 === 0.6.4
 
 * Added require statement for monthly_recurring_revenue proxy model.

--- a/lib/lobbyist/v2/workflow_system.rb
+++ b/lib/lobbyist/v2/workflow_system.rb
@@ -1,8 +1,9 @@
 module Lobbyist
   module V2
     class WorkflowSystem < Lobbyist::V2::Base
-      attr_accessor :id, :name, :version, :status, :database_name, :access_type, :visible
-      attr_accessor :assembly_location, :assembly_version, :created_at, :updated_at
+      attr_accessor :id, :name, :version, :status, :visible, :database_name, :access_type
+      attr_accessor :data_padding_enabled, :use_processor, :respect_commercial_flag
+      attr_accessor :enable_auto_invitations, :created_at, :updated_at
 
       def self.list(params = {})
         create_collection_from_response(get("/v2/workflow_systems.json", params))

--- a/lib/lobbyist/version.rb
+++ b/lib/lobbyist/version.rb
@@ -2,7 +2,7 @@ module Lobbyist
   class Version
     MAJOR = 0 unless defined? Lobbyist::Version::MAJOR
     MINOR = 6 unless defined? Lobbyist::Version::MINOR
-    PATCH = 4 unless defined? Lobbyist::Version::PATCH
+    PATCH = 5 unless defined? Lobbyist::Version::PATCH
 
     class << self
 

--- a/lib/lobbyist/workflow_system.rb
+++ b/lib/lobbyist/workflow_system.rb
@@ -1,8 +1,9 @@
 module Lobbyist
 
   class WorkflowSystem < Lobbyist::Base
-    attr_accessor :id, :name, :version, :status, :database_name, :access_type
-    attr_accessor :assembly_location, :assembly_version, :created_at, :updated_at
+    attr_accessor :id, :name, :version, :status, :visible, :database_name, :access_type
+    attr_accessor :data_padding_enabled, :use_processor, :respect_commercial_flag
+    attr_accessor :enable_auto_invitations, :created_at, :updated_at
 
     def self.list(params = {})
       create_collection_from_response(get("/v1/workflow_systems.json", params))


### PR DESCRIPTION
Why: They were out of date with the actual fields. Both V1 and V2 are now current.