### PR TITLE
CA-4362 Removed bad status logic.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+=== 0.6.9
+
+* Removed invalid company status updating logic from the Company.update method.
+
 === 0.6.8
 
 * Added Support for CategoryAggregateInsights

--- a/lib/lobbyist/v2/company.rb
+++ b/lib/lobbyist/v2/company.rb
@@ -83,9 +83,6 @@ module Lobbyist
       end
 
       def self.update(id, params = {})
-        if params[:is_active].present?
-          params.merge!(:status => params[:is_active] == 'true' ? 'active' : 'inactive')
-        end
         create_from_response(put("/v2/companies/#{id}.json", {'company' => params}))
       end
 

--- a/lib/lobbyist/version.rb
+++ b/lib/lobbyist/version.rb
@@ -2,7 +2,7 @@ module Lobbyist
   class Version
     MAJOR = 0 unless defined? Lobbyist::Version::MAJOR
     MINOR = 6 unless defined? Lobbyist::Version::MINOR
-    PATCH = 8 unless defined? Lobbyist::Version::PATCH
+    PATCH = 9 unless defined? Lobbyist::Version::PATCH
 
     class << self
 


### PR DESCRIPTION
Why: The is_active flag and the company status field should not be linked.